### PR TITLE
Fix: Field type for one-time passwords is "OTP" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ The 1Password Connect server provides a REST API that can be used to securely ac
 
 ### Create Server and Access Token
 
-You can use the 1Password command-line tool to set up a 1Password Connect server and issue tokens for it.
-Set up a 1Password Connect server:
+You can use the [1Password command-line tool](https://1password.com/downloads/command-line/) to set up a 1Password Connect server and issue tokens for it.
+
+First, set up a 1Password Connect server:
 
 ```sh
 op create connect server <name> --vaults <vault>[,<vault>]
 ```
 
 You'll get a `1password-credentials.json` file that you'll use to deploy the Connect server.
+
 Issue a token:
 
 ```sh
@@ -30,9 +32,9 @@ Deploying 1Password Connect requires 2 containers to be running in your infrastr
 Deployment Examples:
 
 - [Helm](https://github.com/1Password/connect-helm-charts/tree/main/charts/connect#deploying-1password-connect)
-- [Docker Compose](./examples/docker/compose/README.md)
-- [Kubernetes Manifest](./examples/kubernetes/README.md)
-- [AWS Elastic Container Service](./examples/aws-ecs-fargate/README.md)
+- [Docker Compose](./examples/docker/compose)
+- [Kubernetes Manifest](./examples/kubernetes)
+- [AWS Elastic Container Service](./examples/aws-ecs-fargate)
 
 ### Server Configuration
 

--- a/docs/openapi/spec.yaml
+++ b/docs/openapi/spec.yaml
@@ -253,7 +253,7 @@ components:
             - "EMAIL"
             - "CONCEALED"
             - "URL"
-            - "TOTP"
+            - "OTP"
             - "DATE"
             - "MONTH_YEAR"
             - "MENU"


### PR DESCRIPTION
# Summary

This PR is a documentation fix for the 1Password Connect API spec.

A customer in the 1Password forums reported our spec defined the One-time Password field type as `TOTP` when it _should_ be `OTP`. 

I confirmed this by running the following requests against **Connect v1.5.0**:


<details>
<summary> ❌  Failure (HTTP 400 Validation Error, field type = "totp")</summary>

```
POST http://localhost:8080/v1/vaults/vault_id_here/items
Accept: application/json
Authorization: Bearer <token>

{
  "title": "Testing OTP vs TOTP",
  "vault": {
    "id": "vault_id_here"
  },
  "category": "LOGIN",
  "fields": [
    {
      "type": "totp",
      "label": "example1",
      "value":"otpauth://totp/Example:steve@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
    }
  ]
}
```

Response:
```
{
  "status": 400,
  "message": "Validation: (validateVaultItem failed to Validate), Couldn't validate the item: \"[ItemValidator] has found 1 errors, 0 warnings: \\nErrors:{1. details.sections[0].fields[0] has unsupported field type: totp}\""
}
```

</details>

<details>
<summary> ✅   Success (HTTP 200, field type = "otp")</summary>

```
POST http://localhost:8080/v1/vaults/vault_id_here/items
Accept: application/json
Authorization: Bearer <token>

{
  "title": "Testing OTP vs TOTP",
  "vault": {
    "id": "vault_id_here"
  },
  "category": "LOGIN",
  "fields": [
    {
      "type": "otp",
      "label": "example1",
      "value":"otpauth://totp/Example:steve@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
    }
  ]
}
```
</details>

I will check our other integrations and documentation to make sure we specify the `OTP` field type.