### PR TITLE
Added ports back to the Connect Sync container

### DIFF
--- a/examples/docker/compose/docker-compose.yaml
+++ b/examples/docker/compose/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       - "data:/home/opuser/.op/data"
   op-connect-sync:
     image: 1password/connect-sync:latest
+    ports:
+      - "8081:8080"
     volumes:
       - "./1password-credentials.json:/home/opuser/.op/1password-credentials.json"
       - "data:/home/opuser/.op/data"


### PR DESCRIPTION
After confirming with @edif2008, the Connect Sync container should also have ports mapped per the example found in the [developer documentation](https://developer.1password.com/docs/connect/get-started#:~:text=credentials.json%20file.-,Download%20an%20example,-docker%2Dcompose.yaml). 