### PR TITLE
Update README.md

### DIFF
--- a/examples/docker/compose/README.md
+++ b/examples/docker/compose/README.md
@@ -10,7 +10,7 @@ Before you begin, make sure you have your Connect server's `1password-credential
 volumes:
   - "<filepath_here>/1password-credentials.json:/home/opuser/.op/1password-credentials.json"
 ```
-
+and on Linux make sure you give others right to read via `chmod w+r 1password-credentials.json` as internal docker opuser id hardcoded to id 999. 
 ### Start the Docker containers:
 ```bash
 docker-compose up [-d]


### PR DESCRIPTION
I bumbed into the same issue as https://1password.community/discussion/126461/docker-compose-permission-denied , default ubuntu id 1001 internal opuser id 999, on system which doesn't ignore user's permissions (like Linux) 1password can't read the shared credentials file.