### PR TITLE
Add 1Password Connect Server Deployment on Azure Container Apps with ARM Template

### DIFF
--- a/examples/beta/azure-container-apps-arm/README.md
+++ b/examples/beta/azure-container-apps-arm/README.md
@@ -44,7 +44,7 @@ To test if your Connect Server is online, choose **Overview** in your applicatio
 ```sh
 curl --silent --show-error --request GET --header "Accept: application/json" \
   --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
-  https:/op-connect.example.com/health
+  https://op-connect.example.com/health
 ```
 
 <details>

--- a/examples/beta/azure-container-apps-arm/README.md
+++ b/examples/beta/azure-container-apps-arm/README.md
@@ -39,9 +39,45 @@ Before you begin, ensure you have an Azure account with permission to create a C
 
 Once your deployment is complete, click **Go to resource group** and click on the container app you created.
 
-To test if your Connect Server is online, choose **Overview** in your application's sidebar, then click your **Application Url** link. This is your **Connect Server URL**. Use your 1Password Connect access token to interact with the API (e.g., via a `curl` request or a client application) to verify that your Connect Server is connected to your 1Password account.
+To test if your Connect Server is online, choose **Overview** in your application's sidebar, then copy your **Application Url** link. This is your **Connect Server URL**. Use your 1Password Connect access token to interact with the API (e.g., via a `curl` request or a client application) to verify that your Connect Server is connected to your 1Password account.
 
-Refer to the [1Password Connect documentation](https://developer.1password.com/docs/connect) for details on making API requests.
+```sh
+curl --silent --show-error --request GET --header "Accept: application/json" \
+  --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
+  https:/op-connect.example.com/health
+```
+
+<details>
+<summary>Example JSON response:</summary>
+
+```json
+{
+  "name": "1Password Connect API",
+  "version": "1.7.3",
+  "dependencies":
+    [
+      {
+        "service": "sqlite",
+        "status": "ACTIVE",
+        "message": "Connected to /home/opuser/.op/data/1password.sqlite",
+      },
+      {
+        "service": "account_data",
+        "status": "AVAILABLE",
+        "message": "Account data is available",
+      },
+      { "service": "sync", "status": "ACTIVE" },
+      {
+        "service": "1Password",
+        "status": "UNINITIALIZED",
+        "message": "Make a request with a valid bearer token to initialize",
+      },
+    ],
+}
+```
+
+</details>
+<br />
 
 ## Step 4: Integrate with your application
 

--- a/examples/beta/azure-container-apps-arm/README.md
+++ b/examples/beta/azure-container-apps-arm/README.md
@@ -51,29 +51,38 @@ curl --silent --show-error --request GET --header "Accept: application/json" \
 <summary>Example JSON response:</summary>
 
 ```json
-{
-  "name": "1Password Connect API",
-  "version": "1.7.3",
-  "dependencies":
-    [
-      {
-        "service": "sqlite",
-        "status": "ACTIVE",
-        "message": "Connected to /home/opuser/.op/data/1password.sqlite",
-      },
-      {
-        "service": "account_data",
-        "status": "AVAILABLE",
-        "message": "Account data is available",
-      },
-      { "service": "sync", "status": "ACTIVE" },
-      {
-        "service": "1Password",
-        "status": "UNINITIALIZED",
-        "message": "Make a request with a valid bearer token to initialize",
-      },
-    ],
-}
+[
+  {
+    "attributeVersion": 1,
+    "contentVersion": 9,
+    "createdAt": "2025-03-21T13:06:35Z",
+    "id": "hgm3sn37vkj3lsdkeouq46wyca",
+    "items": 5,
+    "name": "REDACTED",
+    "type": "USER_CREATED",
+    "updatedAt": "2025-04-18T16:38:40Z"
+  },
+  {
+    "attributeVersion": 1,
+    "contentVersion": 2,
+    "createdAt": "2025-03-21T02:15:33Z",
+    "id": "mn4w65hq6ar7nc2fc7qgoru3ki",
+    "items": 1,
+    "name": "REDACTED",
+    "type": "USER_CREATED",
+    "updatedAt": "2025-03-21T02:16:32Z"
+  },
+  {
+    "attributeVersion": 1,
+    "contentVersion": 94,
+    "createdAt": "2025-03-21T15:20:41Z",
+    "id": "z4s56cbejab6q6urod3l5icqky",
+    "items": 3,
+    "name": "REDACTED",
+    "type": "USER_CREATED",
+    "updatedAt": "2025-04-29T02:49:13Z"
+  }
+]
 ```
 
 </details>

--- a/examples/beta/azure-container-apps-arm/README.md
+++ b/examples/beta/azure-container-apps-arm/README.md
@@ -44,7 +44,7 @@ To test if your Connect Server is online, choose **Overview** in your applicatio
 ```sh
 curl --silent --show-error --request GET --header "Accept: application/json" \
   --header "Authorization: Bearer mF_9.B5f-4.1JqM" \
-  https://op-connect.example.com/health
+  https://op-connect.example.com/v1/vaults
 ```
 
 <details>

--- a/examples/beta/azure-container-apps-arm/README.md
+++ b/examples/beta/azure-container-apps-arm/README.md
@@ -1,0 +1,82 @@
+# Deploy 1Password Connect Server on Azure Container Apps using the Azure Portal
+
+_Learn how to deploy 1Password Connect Server on the [Azure Container Apps](https://azure.microsoft.com/en-us/products/container-apps/#overview) service._
+
+This deployment consists of two [containers](https://learn.microsoft.com/en-us/azure/container-apps/containers): One for the Connect API and another for Connect Sync. There's also an [ingress](https://learn.microsoft.com/en-us/azure/container-apps/ingress-overview) for the API container. There are a few benefits to deploying 1Password Connect Server on Azure Container Apps:
+
+- **Low cost:** For standard deployments, the service will host your Connect Server for ~$16 USD/month (as of January 2024). Container Apps pricing is variable based on activity, and you can learn more on [Microsoft's pricing page](https://azure.microsoft.com/en-us/pricing/details/container-apps/).
+- **Automatic DNS record management:** You don't need to manage a DNS record. Azure Container Apps automatically provides a unique one for your Connect Server domain.
+- **Automatic TLS certificate management:** Azure Container Apps automatically handles TLS certificate management on your behalf.
+
+## Before you begin
+
+Before you begin, ensure you have an Azure account with permission to create a Container App. You'll also need the `1password-credentials.json` file for your 1Password Connect Server, which contains the credentials for authenticating the server.
+
+> [!NOTE]
+> If you don't have an Azure account, you can sign up for a free trial with starting credit: https://azure.microsoft.com/free/
+
+## Step 1: Download the template file
+
+1. Download the [ARM(Azure Resource Manager) template](./aca-op-connect-server-template.json) file using the download icon at the top right.
+
+## Step 2: Create the Container App
+
+1. Sign in to the Azure Portal and go to the [Deploy a custom template](https://portal.azure.com/#create/Microsoft.Template) page.
+2. Click **Build your own template in the editor**.
+3. Click **Load file** and upload the template file you downloaded earlier. Then click **Save**.
+4. Fill out the following fields:
+   - **Subscription** : Choose the subscription you prefer.
+   - **Resource group**: Choose an existing Resource Group or create a new one using **Create new** button.
+   - **Region**: Choose the region you prefer.
+   - **Container App Name**: Enter a name you'd like to use, default will be `op-connect-con-app`.
+   - **Container App Env Name**: Enter a name you'd like to use, default will be `op-connect-con-env`.
+   - **Container App Log Analytics Name**: Enter a name you'd like to use, default will be `op-connect-con-app-log-analytics`.
+   - **Credentials** : Paste the entire contents of the `1password-credentials.json` file.
+5. Click **Review + create**.
+6. Once the validation succeeds, click **Create**. It is expected to take a couple of minutes to complete the deployment.
+
+## Step 3: Test your Connect Server
+
+Once your deployment is complete, click **Go to resource group** and click on the container app you created.
+
+To test if your Connect Server is online, choose **Overview** in your application's sidebar, then click your **Application Url** link. This is your **Connect Server URL**. Use your 1Password Connect access token to interact with the API (e.g., via a `curl` request or a client application) to verify that your Connect Server is connected to your 1Password account.
+
+Refer to the [1Password Connect documentation](https://developer.1password.com/docs/connect) for details on making API requests.
+
+## Step 4: Integrate with your application
+
+To use the Connect Server, configure your application to communicate with the Connect Server URL using the access token provided in your 1Password account. Follow the [1Password Connect integration guide](https://developer.1password.com/docs/connect) to set up your application.
+
+<hr>
+
+## Update your Connect Server in the Azure Portal
+
+> [!TIP]
+> Check for 1Password Connect Server updates on the [1Password releases page](https://releases.1password.com/).
+
+1. Within your deployed 1Password Connect Server Container App in the [Azure Container Apps Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps), select **Containers** from the sidebar.
+2. Click **Edit and deploy**.
+3. Select the checkbox next to your **connect-api** container, then choose **Edit**.
+4. Change the version number in the **Image and Tag** field, `1password/connect-api:latest`, to match the latest version from our [1Password releases page](https://releases.1password.com/).
+5. Repeat for the **connect-sync** container, updating `1password/connect-sync:latest` to the same version.
+6. Select **Save**.
+7. Select **Create** to deploy a new revision using the updated images.
+8. Test your Connect Server URL with your access token to verify the update.
+
+## Get help
+
+### How to update the **credentials** secret
+
+To use a new `1password-credentials.json` credentials file for your Connect Server, replace the secret in your Container App:
+
+<details>
+<summary>Replace your <code>credentials</code> secret using the Azure Portal</summary>
+
+1. Open the Azure Portal and go to the [Container Apps](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.App%2FcontainerApps) page.
+2. Choose **Secrets** from the Settings section in the sidebar.
+3. Edit the **credentials** secret and paste the entire contents of your new `1password-credentials.json` file.
+4. Select the checkbox and click **Save**.
+5. Choose the **Revisions** from the Application section in the sidebar.
+6. Click your current active revision and choose **Restart** in the details pane.
+7. Test your Connect Server URL with your new access token to [test your Connect Server](#step-3-test-your-connect-server).
+</details>

--- a/examples/beta/azure-container-apps-arm/aca-op-connect-server-template.json
+++ b/examples/beta/azure-container-apps-arm/aca-op-connect-server-template.json
@@ -1,0 +1,156 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "logAnalyticsWorkspaceName": {
+        "type": "string",
+        "defaultValue": "op-connect-con-app-log-analytics",
+        "metadata": {
+          "description": "The name of the Log Analytics Workspace."
+        }
+      },
+      "containerAppName": {
+        "type": "string",
+        "defaultValue": "op-connect-con-app",
+        "metadata": {
+          "description": "The name of the Container App."
+        }
+      },
+      "containerAppEnvName": {
+        "type": "string",
+        "defaultValue": "op-connect-con-env",
+        "metadata": {
+          "description": "The name of the Container App Environment."
+        }
+      },
+      "credentialsBase64": {
+        "type": "securestring",
+        "metadata": {
+          "description": "Base64 encoded value of 1password-credentials.json."
+        }
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.OperationalInsights/workspaces",
+        "apiVersion": "2022-10-01",
+        "name": "[parameters('logAnalyticsWorkspaceName')]",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "sku": {
+            "name": "PerGB2018"
+          }
+        }
+      },
+      {
+        "type": "Microsoft.App/managedEnvironments",
+        "apiVersion": "2023-05-01",
+        "name": "[parameters('containerAppEnvName')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+        ],
+        "properties": {
+          "appLogsConfiguration": {
+            "destination": "log-analytics",
+            "logAnalyticsConfiguration": {
+              "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))).customerId]",
+              "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]"
+            }
+          },
+          "zoneRedundant": false
+        }
+      },
+      {
+        "type": "Microsoft.App/containerApps",
+        "apiVersion": "2023-05-01",
+        "name": "[parameters('containerAppName')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]"
+        ],
+        "properties": {
+          "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]",
+          "configuration": {
+            "secrets": [
+              {
+                "name": "credentials",
+                "value": "[parameters('credentialsBase64')]"
+              }
+            ],
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "external": true,
+              "targetPort": 8080,
+              "allowInsecure": false,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ]
+            }
+          },
+          "template": {
+            "containers": [
+              {
+                "name": "connect-api",
+                "image": "docker.io/1password/connect-api:latest",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                },
+                "env": [
+                  {
+                    "name": "OP_SESSION",
+                    "secretRef": "credentials"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "volumeName": "data",
+                    "mountPath": "/home/opuser/.op/data"
+                  }
+                ]
+              },
+              {
+                "name": "connect-sync",
+                "image": "docker.io/1password/connect-sync:latest",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                },
+                "env": [
+                  {
+                    "name": "OP_SESSION",
+                    "secretRef": "credentials"
+                  },
+                  {
+                    "name": "OP_HTTP_PORT",
+                    "value": "8081"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "volumeName": "data",
+                    "mountPath": "/home/opuser/.op/data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "data",
+                "storageType": "EmptyDir"
+              }
+            ],
+            "scale": {
+              "minReplicas": 1,
+              "maxReplicas": 1
+            }
+          }
+        }
+      }
+    ]
+  }
+  

--- a/examples/beta/azure-container-apps-arm/aca-op-connect-server-template.json
+++ b/examples/beta/azure-container-apps-arm/aca-op-connect-server-template.json
@@ -122,7 +122,7 @@
               "env": [
                 {
                   "name": "OP_HTTP_PORT",
-                  "value": "8080"
+                  "value": "8081"
                 }
               ],
               "volumeMounts": [

--- a/examples/beta/azure-container-apps-arm/aca-op-connect-server-template.json
+++ b/examples/beta/azure-container-apps-arm/aca-op-connect-server-template.json
@@ -1,156 +1,165 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "logAnalyticsWorkspaceName": {
-        "type": "string",
-        "defaultValue": "op-connect-con-app-log-analytics",
-        "metadata": {
-          "description": "The name of the Log Analytics Workspace."
-        }
-      },
-      "containerAppName": {
-        "type": "string",
-        "defaultValue": "op-connect-con-app",
-        "metadata": {
-          "description": "The name of the Container App."
-        }
-      },
-      "containerAppEnvName": {
-        "type": "string",
-        "defaultValue": "op-connect-con-env",
-        "metadata": {
-          "description": "The name of the Container App Environment."
-        }
-      },
-      "credentialsBase64": {
-        "type": "securestring",
-        "metadata": {
-          "description": "Base64 encoded value of 1password-credentials.json."
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logAnalyticsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "op-connect-con-app-log-analytics",
+      "metadata": {
+        "description": "The name of the Log Analytics Workspace."
+      }
+    },
+    "containerAppName": {
+      "type": "string",
+      "defaultValue": "op-connect-con-app",
+      "metadata": {
+        "description": "The name of the Container App."
+      }
+    },
+    "containerAppEnvName": {
+      "type": "string",
+      "defaultValue": "op-connect-con-env",
+      "metadata": {
+        "description": "The name of the Container App Environment."
+      }
+    },
+    "credentials": {
+      "type": "SecureString",
+      "metadata": {
+        "description": "The plain text contents of 1password-credentials.json."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[parameters('logAnalyticsWorkspaceName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
         }
       }
     },
-    "resources": [
-      {
-        "type": "Microsoft.OperationalInsights/workspaces",
-        "apiVersion": "2022-10-01",
-        "name": "[parameters('logAnalyticsWorkspaceName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "sku": {
-            "name": "PerGB2018"
+    {
+      "type": "Microsoft.App/managedEnvironments",
+      "apiVersion": "2023-05-01",
+      "name": "[parameters('containerAppEnvName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+      ],
+      "properties": {
+        "appLogsConfiguration": {
+          "destination": "log-analytics",
+          "logAnalyticsConfiguration": {
+            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))).customerId]",
+            "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]"
           }
-        }
-      },
-      {
-        "type": "Microsoft.App/managedEnvironments",
-        "apiVersion": "2023-05-01",
-        "name": "[parameters('containerAppEnvName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
-        ],
-        "properties": {
-          "appLogsConfiguration": {
-            "destination": "log-analytics",
-            "logAnalyticsConfiguration": {
-              "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))).customerId]",
-              "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]"
+        },
+        "zoneRedundant": false
+      }
+    },
+    {
+      "type": "Microsoft.App/containerApps",
+      "apiVersion": "2023-05-01",
+      "name": "[parameters('containerAppName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]"
+      ],
+      "properties": {
+        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]",
+        "configuration": {
+          "secrets": [
+            {
+              "name": "credentials",
+              "value": "[parameters('credentials')]"
             }
-          },
-          "zoneRedundant": false
-        }
-      },
-      {
-        "type": "Microsoft.App/containerApps",
-        "apiVersion": "2023-05-01",
-        "name": "[parameters('containerAppName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]"
-        ],
-        "properties": {
-          "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppEnvName'))]",
-          "configuration": {
-            "secrets": [
+          ],
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "external": true,
+            "targetPort": 8080,
+            "allowInsecure": false,
+            "traffic": [
               {
-                "name": "credentials",
-                "value": "[parameters('credentialsBase64')]"
+                "latestRevision": true,
+                "weight": 100
               }
-            ],
-            "activeRevisionsMode": "Single",
-            "ingress": {
-              "external": true,
-              "targetPort": 8080,
-              "allowInsecure": false,
-              "traffic": [
+            ]
+          }
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "connect-api",
+              "image": "docker.io/1password/connect-api:latest",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              },
+              "volumeMounts": [
                 {
-                  "latestRevision": true,
-                  "weight": 100
+                  "volumeName": "data",
+                  "mountPath": "/home/opuser/.op/data"
+                },
+                {
+                  "volumeName": "credentials",
+                  "mountPath": "/home/opuser/.op/1password-credentials.json",
+                  "subPath": "1password-credentials.json"
+                }
+              ]
+            },
+            {
+              "name": "connect-sync",
+              "image": "docker.io/1password/connect-sync:latest",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              },
+              "env": [
+                {
+                  "name": "OP_HTTP_PORT",
+                  "value": "8080"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "volumeName": "data",
+                  "mountPath": "/home/opuser/.op/data"
+                },
+                {
+                  "volumeName": "credentials",
+                  "mountPath": "/home/opuser/.op/1password-credentials.json",
+                  "subPath": "1password-credentials.json"
                 }
               ]
             }
-          },
-          "template": {
-            "containers": [
-              {
-                "name": "connect-api",
-                "image": "docker.io/1password/connect-api:latest",
-                "resources": {
-                  "cpu": 0.25,
-                  "memory": "0.5Gi"
-                },
-                "env": [
-                  {
-                    "name": "OP_SESSION",
-                    "secretRef": "credentials"
-                  }
-                ],
-                "volumeMounts": [
-                  {
-                    "volumeName": "data",
-                    "mountPath": "/home/opuser/.op/data"
-                  }
-                ]
-              },
-              {
-                "name": "connect-sync",
-                "image": "docker.io/1password/connect-sync:latest",
-                "resources": {
-                  "cpu": 0.25,
-                  "memory": "0.5Gi"
-                },
-                "env": [
-                  {
-                    "name": "OP_SESSION",
-                    "secretRef": "credentials"
-                  },
-                  {
-                    "name": "OP_HTTP_PORT",
-                    "value": "8081"
-                  }
-                ],
-                "volumeMounts": [
-                  {
-                    "volumeName": "data",
-                    "mountPath": "/home/opuser/.op/data"
-                  }
-                ]
-              }
-            ],
-            "volumes": [
-              {
-                "name": "data",
-                "storageType": "EmptyDir"
-              }
-            ],
-            "scale": {
-              "minReplicas": 1,
-              "maxReplicas": 1
+          ],
+          "volumes": [
+            {
+              "name": "data",
+              "storageType": "EmptyDir"
+            },
+            {
+              "name": "credentials",
+              "storageType": "Secret",
+              "secrets": [
+                {
+                  "secretRef": "credentials",
+                  "path": "1password-credentials.json"
+                }
+              ]
             }
+          ],
+          "scale": {
+            "minReplicas": 1,
+            "maxReplicas": 1
           }
         }
       }
-    ]
-  }
-  
+    }
+  ]
+}


### PR DESCRIPTION
# Add 1Password Connect Server Deployment on Azure Container Apps with ARM Template

This pull request introduces a new deployment option for the 1Password Connect Server on Azure Container Apps, providing a standardized way to deploy the Connect Server using an ARM template and comprehensive documentation.

## Changes
- **ARM Template** (`aca-op-connect-server-template.json`):
  - Deploys the Connect Server with `connect-api` and `connect-sync` containers.
  - Configures plain text `credentials` as a `SecureString`, mounted as `/home/opuser/.op/1password-credentials.json` for secure authentication.
  - Sets up Log Analytics and ingress for monitoring and API access.
- **Documentation** (`README.md`):
  - Provides step-by-step instructions for deploying, testing, and updating the Connect Server via the Azure Portal.
  - Includes guidance on using the Connect Server URL with an access token for API integration.

## Testing
- Deployed the template in an Azure sandbox environment, verifying successful setup and API connectivity using the Connect Server URL and access token.
- Followed `README.md` instructions to confirm clarity and accuracy.

## Notes
- Please review the template for compatibility with Azure Container Apps and the README for consistency with other deployment guides in the repository.