### PR TITLE
1Password Connect API Gateway Deployment with VPC Flexibility and Credential Encoding

### DIFF
--- a/examples/beta/aws-ecs-apigateway-cfn/README.md
+++ b/examples/beta/aws-ecs-apigateway-cfn/README.md
@@ -1,0 +1,33 @@
+# AWS ECS with Fargate and API Gateway
+
+The CloudFormation document in this folder will create the following resources, along with the necessary rules, groups, and policies to make them work.
+
+The result is a publicly accessible hostname (via HTTPS) that routes requests to a 1Password Connect instance running in AWS Fargate, using API Gateway for secure ingress. You can use your own VPC and subnets.
+
+To customize further, like deploying into an existing ECS cluster, use this CloudFormation as a starting point and tweak it with a text editor or Amazon's CloudFormation Designer tool.
+
+## Networking Resources
+
+- A VPC (optional, if you don’t provide your own)
+- 2 Public subnets (optional, if you don’t provide your own)
+- An Internet Gateway (optional, if creating a VPC)
+- An API Gateway with HTTPS
+- A VPC Link for API Gateway to route to the Fargate service
+
+## ECS Resources
+
+- An ECS Cluster
+- Task Definition
+  - `1password/connect-api` container
+  - `1password/connect-sync` container
+- Service Discovery for internal routing
+
+## Getting Started
+
+When [importing this CloudFormation template](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-template.html), you’ll be prompted to provide the following:
+
+- **CredentialsJson**: The plain JSON contents of your `1password-credentials.json` file (e.g., `{"token":"your-token"}`). The template will encode this to base64 and store it securely in AWS Secrets Manager.
+- **VPCID**, **PublicSubnets** (optional): Provide these if you want to use an existing VPC and subnets. Leave as default to create a new VPC.
+- **VPCCIDR** (optional): Sets the CIDR for a new VPC if you’re creating one; ignored if using an existing VPC.
+
+For more details, see the deployment note in the template description.

--- a/examples/beta/aws-ecs-apigateway-cfn/README.md
+++ b/examples/beta/aws-ecs-apigateway-cfn/README.md
@@ -8,11 +8,12 @@ To customize further, like deploying into an existing ECS cluster, use this Clou
 
 ## Networking Resources
 
+- A VPC Link for API Gateway to route to the Fargate service
+- An API Gateway with HTTPS
 - A VPC (optional, if you don’t provide your own)
 - 2 Public subnets (optional, if you don’t provide your own)
 - An Internet Gateway (optional, if creating a VPC)
-- An API Gateway with HTTPS
-- A VPC Link for API Gateway to route to the Fargate service
+
 
 ## ECS Resources
 

--- a/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
+++ b/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
@@ -1,11 +1,12 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Deploys 1Password Connect on Fargate with API Gateway. Creates a VPC if not provided, handles creds with a Lambda for base64.
+Description: Sets up 1Password Connect on Fargate with API Gateway, stores 1password-credentials.json in Secrets Manager, and makes a VPC if you don’t give one
 
+# Makes the params look nice in the AWS console
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Network & Creds Setup
+          default: Network & Credentials Setup
         Parameters:
           - VPCID
           - VPCCIDR
@@ -13,7 +14,7 @@ Metadata:
           - CredentialsJson
     ParameterLabels:
       CredentialsJson:
-        default: 1Password Creds JSON
+        default: 1Password Credentials JSON
       VPCID:
         default: VPC ID
       VPCCIDR:
@@ -21,122 +22,53 @@ Metadata:
       PublicSubnets:
         default: Public Subnets
 
+# Stuff you can tweak when you deploy
 Parameters:
   VPCID:
     Type: String
-    Description: Existing VPC ID to use (leave blank to create a new one)
+    Description: Got a VPC ID? Toss it here, or leave it blank to make a new one
     Default: ""
   VPCCIDR:
     Type: String
-    Description: CIDR for the new VPC if creating one
+    Description: CIDR for a new VPC if we're making one
     Default: 10.0.0.0/16
   PublicSubnets:
     Type: CommaDelimitedList
-    Description: List of public subnet IDs (need at least 2)
+    Description: List of public subnet IDs, need at least 2 if you're using an existing VPC
     Default: ""
   CredentialsJson:
     Type: String
     Description: Your 1password-credentials.json as plain JSON
     NoEcho: true
     MinLength: 1
-    ConstraintDescription: can't be empty
+    ConstraintDescription: gotta have something here
 
+# Check if we need to whip up a new VPC
 Conditions:
-  CreateVPC: !Equals [!Ref VPCID, ""]
+  CreateVPC:
+    Fn::Equals:
+      - !Ref VPCID
+      - ""
+
+# Predefined CIDRs for the VPC and subnets
+Mappings:
+  SubnetConfig:
+    VPC:
+      CIDR: '10.0.0.0/16'
+    PublicOne:
+      CIDR: '10.0.1.0/24'
+    PublicTwo:
+      CIDR: '10.0.2.0/24'
 
 Resources:
-  # Lambda role for base64 encoding
-  LambdaExecutionRole:
-    Type: AWS::IAM::Role
+  # Secret to store the base64-encoded credentials
+  CredentialsSecret:
+    Type: AWS::SecretsManager::Secret
     Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: SecretsManagerAccess
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - secretsmanager:CreateSecret
-                  - secretsmanager:PutSecretValue
-                  - secretsmanager:DeleteSecret
-                Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CredentialsSecret-${AWS::StackName}*'
-        - PolicyName: LambdaLogs
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/Base64EncoderFunction-${AWS::StackName}:*'
+      Name: !Sub 'CredentialsSecret-${AWS::StackName}'
+      SecretString: !Base64 { "Fn::Sub": "${CredentialsJson}" }
 
-  # Lambda to encode creds to base64
-  Base64EncoderFunction:
-    Type: AWS::Lambda::Function
-    DependsOn: LambdaExecutionRole
-    Properties:
-      FunctionName: !Sub 'Base64EncoderFunction-${AWS::StackName}'
-      Handler: index.handler
-      Role: !GetAtt LambdaExecutionRole.Arn
-      Code:
-        ZipFile: |
-          import json, base64, boto3, cfnresponse
-
-          def handler(event, context):
-              try:
-                  props = event['ResourceProperties']
-                  req_type = event['RequestType']
-                  plain_json = props['PlainJson']
-                  secret_name = props['SecretName']
-
-                  # quick check for valid JSON
-                  json.loads(plain_json)
-                  # encode to base64
-                  base64_creds = base64.b64encode(plain_json.encode('utf-8')).decode('utf-8')
-
-                  secrets_client = boto3.client('secretsmanager')
-                  # build the ARN
-                  region = context.invoked_function_arn.split(':')[3]
-                  account_id = context.invoked_function_arn.split(':')[4]
-                  secret_arn = f'arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}'
-
-                  if req_type == 'Create':
-                      secrets_client.create_secret(Name=secret_name, SecretString=base64_creds)
-                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SecretArn': secret_arn})
-                  elif req_type == 'Update':
-                      secrets_client.put_secret_value(SecretId=secret_name, SecretString=base64_creds)
-                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SecretArn': secret_arn})
-                  elif req_type == 'Delete':
-                      try:
-                          secrets_client.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
-                      except:
-                          pass
-                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-                  else:
-                      cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': f'Bad request type: {req_type}'})
-              except Exception as e:
-                  cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)})
-      Timeout: 15
-      MemorySize: 128
-      Runtime: python3.12
-
-  # Custom resource to trigger Lambda for creds encoding
-  Base64CredentialsSecret:
-    Type: Custom::Base64Secret
-    DependsOn: Base64EncoderFunction
-    Properties:
-      ServiceToken: !GetAtt Base64EncoderFunction.Arn
-      PlainJson: !Ref CredentialsJson
-      SecretName: !Sub 'CredentialsSecret-${AWS::StackName}'
-
-  # VPC stuff - only creates if VPCID is empty
+  # VPC stuff if we need to make one
   VPC:
     Condition: CreateVPC
     Type: AWS::EC2::VPC
@@ -145,19 +77,19 @@ Resources:
       EnableDnsSupport: true
       EnableDnsHostnames: true
 
-  PublicSubnetOne:
+  PublicSubnetOne: # first subnet for the VPC
     Condition: CreateVPC
     Type: AWS::EC2::Subnet
     Properties:
-      MapPublicIpOnLaunch: true
-      VpcId: !Ref VPC
-      CidrBlock: '10.0.1.0/24'
       AvailabilityZone:
         Fn::Select:
           - 0
           - Fn::GetAZs: ''
+      VpcId: !Ref VPC
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
+      MapPublicIpOnLaunch: true
 
-  PublicSubnetTwo:
+  PublicSubnetTwo: # second subnet for the VPC
     Condition: CreateVPC
     Type: AWS::EC2::Subnet
     Properties:
@@ -166,10 +98,10 @@ Resources:
           - 1
           - Fn::GetAZs: ''
       VpcId: !Ref VPC
-      CidrBlock: '10.0.2.0/24'
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
       MapPublicIpOnLaunch: true
 
-  InternetGateway: # for internet access if we’re creating a VPC
+  InternetGateway: # need this for internet access in the new VPC
     Condition: CreateVPC
     Type: AWS::EC2::InternetGateway
 
@@ -186,10 +118,10 @@ Resources:
     Properties:
       VpcId: !Ref VPC
 
-  PublicRoute:
+  PublicRoute: # sets up the route to the internet
     Condition: CreateVPC
-    Type: AWS::EC2::Route
     DependsOn: GatewayAttachment
+    Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: '0.0.0.0/0'
@@ -209,7 +141,7 @@ Resources:
       SubnetId: !Ref PublicSubnetTwo
       RouteTableId: !Ref PublicRouteTable
 
-  # ECS Cluster setup
+  # ECS cluster to run stuff
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:
@@ -219,7 +151,7 @@ Resources:
         - CapacityProvider: FARGATE
           Weight: 1
 
-  # Security Groups for Fargate and API Gateway
+  # SGs for Fargate and API Gateway
   FargateContainerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -229,10 +161,11 @@ Resources:
   ApiGatewaySecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
       GroupDescription: API Gateway traffic for 1Password Connect
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
 
-  ApiGatewayEgress:
+  # Security group rules
+  ApiGatewayEgress: # lets API Gateway talk to Fargate
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId: !Ref ApiGatewaySecurityGroup
@@ -250,7 +183,7 @@ Resources:
       ToPort: 8080
       SourceSecurityGroupId: !Ref ApiGatewaySecurityGroup
 
-  ConnectSelfIngress: # allows containers in the same SG to talk
+  ConnectSelfIngress: # lets containers in the same SG talk to each other
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       Description: Ingress from other containers in the same security group
@@ -258,7 +191,7 @@ Resources:
       IpProtocol: -1
       SourceSecurityGroupId: !Ref FargateContainerSecurityGroup
 
-  ConnectPublicEgress:
+  ConnectPublicEgress: # Fargate needs internet to grab images
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId: !Ref FargateContainerSecurityGroup
@@ -326,7 +259,7 @@ Resources:
                   - ec2:DetachNetworkInterface
                 Resource: '*'
 
-  # CloudWatch Logs setup
+  # Logs in CloudWatch
   CloudWatchLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -355,12 +288,12 @@ Resources:
       HealthCheckCustomConfig:
         FailureThreshold: 1
 
-  # Task definition for Connect containers
+  # Task def for the Connect containers
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     DependsOn:
       - ECSTaskExecutionRole
-      - Base64CredentialsSecret
+      - CredentialsSecret
       - CloudWatchLogsGroup
     Properties:
       Cpu: 256
@@ -368,7 +301,7 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
-      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
+      ExecutionRoleArn: !Ref ECSTaskExecutionRole
       TaskRoleArn: !Ref ECSRole
       Volumes:
         - Name: data
@@ -383,7 +316,7 @@ Resources:
               SourceVolume: data
           Secrets:
             - Name: OP_SESSION
-              ValueFrom: !GetAtt Base64CredentialsSecret.SecretArn
+              ValueFrom: !Ref CredentialsSecret
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -400,7 +333,7 @@ Resources:
               Value: '8081'
           Secrets:
             - Name: OP_SESSION
-              ValueFrom: !GetAtt Base64CredentialsSecret.SecretArn
+              ValueFrom: !Ref CredentialsSecret
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -413,9 +346,9 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn:
       - TaskDefinition
-      - Base64CredentialsSecret
       - ApiGatewayStage
       - ConnectServiceDiscovery
+      - FargateContainerSecurityGroup
     Properties:
       ServiceName: connect
       Cluster: !Ref ECSCluster

--- a/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
+++ b/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
@@ -22,7 +22,7 @@ Metadata:
       PublicSubnets:
         default: Public Subnets
 
-# Stuff you can tweak when you deploy
+# Parameters you can tweak when you deploy
 Parameters:
   VPCID:
     Type: String
@@ -432,3 +432,4 @@ Outputs:
     Value: !GetAtt ApiGateway.ApiEndpoint
     Export:
       Name: !Join [ ':', [ !Ref AWS::StackName, 'ExternalUrl' ] ]
+      

--- a/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
+++ b/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
@@ -1,11 +1,11 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Deploy 1Password Connect in AWS Fargate with API Gateway for ingress, converting plain JSON credentials to base64 in Secrets Manager with optional VPC configuration
+Description: Deploys 1Password Connect on Fargate with API Gateway. Creates a VPC if not provided, handles creds with a Lambda for base64.
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Network and Credentials Configuration
+          default: Network & Creds Setup
         Parameters:
           - VPCID
           - VPCCIDR
@@ -13,7 +13,7 @@ Metadata:
           - CredentialsJson
     ParameterLabels:
       CredentialsJson:
-        default: 1Password Credentials JSON
+        default: 1Password Creds JSON
       VPCID:
         default: VPC ID
       VPCCIDR:
@@ -24,37 +24,28 @@ Metadata:
 Parameters:
   VPCID:
     Type: String
-    Description: (Optional) ID of an existing VPC to use for your Connect deployment. If empty, a new VPC and two public subnets will be created.
+    Description: Existing VPC ID to use (leave blank to create a new one)
     Default: ""
   VPCCIDR:
     Type: String
-    Description: A CIDR block for the VPC. Required if VPCID is empty; ignored if specifying a VPCID.
+    Description: CIDR for the new VPC if creating one
     Default: 10.0.0.0/16
   PublicSubnets:
     Type: CommaDelimitedList
-    Description: (Optional) A comma-separated list of two or more public subnet IDs in the specified VPC.
+    Description: List of public subnet IDs (need at least 2)
     Default: ""
   CredentialsJson:
     Type: String
-    Description: The plain JSON contents of the 1password-credentials.json file (e.g., {"token":"your-token",...})
+    Description: Your 1password-credentials.json as plain JSON
     NoEcho: true
     MinLength: 1
-    ConstraintDescription: must not be empty
+    ConstraintDescription: can't be empty
 
 Conditions:
   CreateVPC: !Equals [!Ref VPCID, ""]
 
-Mappings:
-  SubnetConfig:
-    VPC:
-      CIDR: '10.0.0.0/16'
-    PublicOne:
-      CIDR: '10.0.1.0/24'
-    PublicTwo:
-      CIDR: '10.0.2.0/24'
-
 Resources:
-  # Lambda Execution Role
+  # Lambda role for base64 encoding
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -86,88 +77,66 @@ Resources:
                   - logs:PutLogEvents
                 Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/Base64EncoderFunction-${AWS::StackName}:*'
 
-  # Lambda Function for Base64 Encoding
+  # Lambda to encode creds to base64
   Base64EncoderFunction:
     Type: AWS::Lambda::Function
-    DependsOn:
-      - LambdaExecutionRole
+    DependsOn: LambdaExecutionRole
     Properties:
       FunctionName: !Sub 'Base64EncoderFunction-${AWS::StackName}'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
         ZipFile: |
-          import json
-          import base64
-          import boto3
-          import cfnresponse
-          import logging
-
-          logging.basicConfig(level=logging.INFO)
-          logger = logging.getLogger()
+          import json, base64, boto3, cfnresponse
 
           def handler(event, context):
               try:
-                  request_type = event['RequestType']
                   props = event['ResourceProperties']
+                  req_type = event['RequestType']
                   plain_json = props['PlainJson']
                   secret_name = props['SecretName']
 
-                  # Validate JSON input
-                  try:
-                      json.loads(plain_json)
-                  except json.JSONDecodeError:
-                      logger.error('Invalid JSON input')
-                      cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': 'Invalid JSON input'})
+                  # quick check for valid JSON
+                  json.loads(plain_json)
+                  # encode to base64
+                  base64_creds = base64.b64encode(plain_json.encode('utf-8')).decode('utf-8')
 
-                  # Encode plain JSON to base64
-                  base64_credentials = base64.b64encode(plain_json.encode('utf-8')).decode('utf-8')
-
-                  # Initialize Secrets Manager client with retries
-                  secrets_client = boto3.client('secretsmanager', config=boto3.session.Config(retries={'max_attempts': 3}))
-
-                  # Extract region and account ID
+                  secrets_client = boto3.client('secretsmanager')
+                  # build the ARN
                   region = context.invoked_function_arn.split(':')[3]
                   account_id = context.invoked_function_arn.split(':')[4]
                   secret_arn = f'arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}'
 
-                  logger.info(f'Processing {request_type} for secret: {secret_name}')
-                  if request_type == 'Create':
-                      secrets_client.create_secret(Name=secret_name, SecretString=base64_credentials)
-                      logger.info(f'Created secret: {secret_arn}')
+                  if req_type == 'Create':
+                      secrets_client.create_secret(Name=secret_name, SecretString=base64_creds)
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SecretArn': secret_arn})
-                  elif request_type == 'Update':
-                      secrets_client.put_secret_value(SecretId=secret_name, SecretString=base64_credentials)
-                      logger.info(f'Updated secret: {secret_arn}')
+                  elif req_type == 'Update':
+                      secrets_client.put_secret_value(SecretId=secret_name, SecretString=base64_creds)
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SecretArn': secret_arn})
-                  elif request_type == 'Delete':
+                  elif req_type == 'Delete':
                       try:
                           secrets_client.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
-                          logger.info(f'Deleted secret: {secret_name}')
-                      except secrets_client.exceptions.ResourceNotFoundException:
-                          logger.info(f'Secret not found: {secret_name}, skipping deletion')
+                      except:
+                          pass
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
                   else:
-                      logger.error(f'Invalid request type: {request_type}')
-                      cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': f'Invalid request type: {request_type}'})
+                      cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': f'Bad request type: {req_type}'})
               except Exception as e:
-                  logger.error(f'Error: {str(e)}')
                   cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)})
-      Runtime: python3.12
       Timeout: 15
       MemorySize: 128
+      Runtime: python3.12
 
-  # Custom Resource to Create Base64 Secret
+  # Custom resource to trigger Lambda for creds encoding
   Base64CredentialsSecret:
     Type: Custom::Base64Secret
-    DependsOn:
-      - Base64EncoderFunction
+    DependsOn: Base64EncoderFunction
     Properties:
       ServiceToken: !GetAtt Base64EncoderFunction.Arn
       PlainJson: !Ref CredentialsJson
       SecretName: !Sub 'CredentialsSecret-${AWS::StackName}'
 
-  # VPC Configuration
+  # VPC stuff - only creates if VPCID is empty
   VPC:
     Condition: CreateVPC
     Type: AWS::EC2::VPC
@@ -180,13 +149,13 @@ Resources:
     Condition: CreateVPC
     Type: AWS::EC2::Subnet
     Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.1.0/24'
       AvailabilityZone:
         Fn::Select:
           - 0
           - Fn::GetAZs: ''
-      VpcId: !Ref VPC
-      CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
-      MapPublicIpOnLaunch: true
 
   PublicSubnetTwo:
     Condition: CreateVPC
@@ -197,10 +166,10 @@ Resources:
           - 1
           - Fn::GetAZs: ''
       VpcId: !Ref VPC
-      CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
+      CidrBlock: '10.0.2.0/24'
       MapPublicIpOnLaunch: true
 
-  InternetGateway:
+  InternetGateway: # for internet access if we’re creating a VPC
     Condition: CreateVPC
     Type: AWS::EC2::InternetGateway
 
@@ -240,7 +209,7 @@ Resources:
       SubnetId: !Ref PublicSubnetTwo
       RouteTableId: !Ref PublicRouteTable
 
-  # ECS Cluster
+  # ECS Cluster setup
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:
@@ -250,7 +219,7 @@ Resources:
         - CapacityProvider: FARGATE
           Weight: 1
 
-  # Security Groups
+  # Security Groups for Fargate and API Gateway
   FargateContainerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -260,10 +229,9 @@ Resources:
   ApiGatewaySecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: API Gateway traffic for 1Password Connect
       VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+      GroupDescription: API Gateway traffic for 1Password Connect
 
-  # Security Group Rules
   ApiGatewayEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
@@ -282,7 +250,7 @@ Resources:
       ToPort: 8080
       SourceSecurityGroupId: !Ref ApiGatewaySecurityGroup
 
-  ConnectSelfIngress:
+  ConnectSelfIngress: # allows containers in the same SG to talk
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       Description: Ingress from other containers in the same security group
@@ -300,7 +268,7 @@ Resources:
       CidrIp: 0.0.0.0/0
       Description: HTTPS to external services (e.g., Docker Hub)
 
-  # IAM Roles
+  # IAM roles for ECS
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -358,14 +326,14 @@ Resources:
                   - ec2:DetachNetworkInterface
                 Resource: '*'
 
-  # CloudWatch Logs
+  # CloudWatch Logs setup
   CloudWatchLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: onepassword-connect
       RetentionInDays: 30
 
-  # Service Discovery
+  # Service discovery for internal routing
   ServiceDiscoveryNamespace:
     Type: AWS::ServiceDiscovery::PrivateDnsNamespace
     Properties:
@@ -387,7 +355,7 @@ Resources:
       HealthCheckCustomConfig:
         FailureThreshold: 1
 
-  # Task Definition
+  # Task definition for Connect containers
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     DependsOn:
@@ -400,7 +368,7 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
-      ExecutionRoleArn: !Ref ECSTaskExecutionRole
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       TaskRoleArn: !Ref ECSRole
       Volumes:
         - Name: data
@@ -422,7 +390,7 @@ Resources:
               awslogs-group: !Ref CloudWatchLogsGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: connect-api
-        - name: connect-sync
+        - Name: connect-sync
           Image: 1password/connect-sync:latest
           MountPoints:
             - ContainerPath: /home/opuser/.op/data
@@ -440,7 +408,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: connect-sync
 
-  # ECS Service
+  # ECS service to run the containers
   ConnectService:
     Type: AWS::ECS::Service
     DependsOn:
@@ -468,7 +436,7 @@ Resources:
           ContainerPort: 8080
           RegistryArn: !GetAtt ConnectServiceDiscovery.Arn
 
-  # API Gateway
+  # API Gateway setup
   VpcLink:
     Type: AWS::ApiGatewayV2::VpcLink
     Properties:

--- a/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
+++ b/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
@@ -77,7 +77,7 @@ Resources:
       EnableDnsSupport: true
       EnableDnsHostnames: true
 
-  PublicSubnetOne: # first subnet for the VPC
+  PublicSubnetOne:
     Condition: CreateVPC
     Type: AWS::EC2::Subnet
     Properties:
@@ -89,7 +89,7 @@ Resources:
       CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
       MapPublicIpOnLaunch: true
 
-  PublicSubnetTwo: # second subnet for the VPC
+  PublicSubnetTwo:
     Condition: CreateVPC
     Type: AWS::EC2::Subnet
     Properties:
@@ -101,7 +101,7 @@ Resources:
       CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
       MapPublicIpOnLaunch: true
 
-  InternetGateway: # need this for internet access in the new VPC
+  InternetGateway:
     Condition: CreateVPC
     Type: AWS::EC2::InternetGateway
 
@@ -118,7 +118,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
 
-  PublicRoute: # sets up the route to the internet
+  PublicRoute:
     Condition: CreateVPC
     DependsOn: GatewayAttachment
     Type: AWS::EC2::Route
@@ -183,7 +183,7 @@ Resources:
       ToPort: 8080
       SourceSecurityGroupId: !Ref ApiGatewaySecurityGroup
 
-  ConnectSelfIngress: # lets containers in the same SG talk to each other
+  ConnectSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       Description: Ingress from other containers in the same security group
@@ -191,7 +191,7 @@ Resources:
       IpProtocol: -1
       SourceSecurityGroupId: !Ref FargateContainerSecurityGroup
 
-  ConnectPublicEgress: # Fargate needs internet to grab images
+  ConnectPublicEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId: !Ref FargateContainerSecurityGroup

--- a/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
+++ b/examples/beta/aws-ecs-apigateway-cfn/connect-server.yaml
@@ -1,0 +1,533 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Deploy 1Password Connect in AWS Fargate with API Gateway for ingress, converting plain JSON credentials to base64 in Secrets Manager with optional VPC configuration
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network and Credentials Configuration
+        Parameters:
+          - VPCID
+          - VPCCIDR
+          - PublicSubnets
+          - CredentialsJson
+    ParameterLabels:
+      CredentialsJson:
+        default: 1Password Credentials JSON
+      VPCID:
+        default: VPC ID
+      VPCCIDR:
+        default: VPC CIDR
+      PublicSubnets:
+        default: Public Subnets
+
+Parameters:
+  VPCID:
+    Type: String
+    Description: (Optional) ID of an existing VPC to use for your Connect deployment. If empty, a new VPC and two public subnets will be created.
+    Default: ""
+  VPCCIDR:
+    Type: String
+    Description: A CIDR block for the VPC. Required if VPCID is empty; ignored if specifying a VPCID.
+    Default: 10.0.0.0/16
+  PublicSubnets:
+    Type: CommaDelimitedList
+    Description: (Optional) A comma-separated list of two or more public subnet IDs in the specified VPC.
+    Default: ""
+  CredentialsJson:
+    Type: String
+    Description: The plain JSON contents of the 1password-credentials.json file (e.g., {"token":"your-token",...})
+    NoEcho: true
+    MinLength: 1
+    ConstraintDescription: must not be empty
+
+Conditions:
+  CreateVPC: !Equals [!Ref VPCID, ""]
+
+Mappings:
+  SubnetConfig:
+    VPC:
+      CIDR: '10.0.0.0/16'
+    PublicOne:
+      CIDR: '10.0.1.0/24'
+    PublicTwo:
+      CIDR: '10.0.2.0/24'
+
+Resources:
+  # Lambda Execution Role
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: SecretsManagerAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:CreateSecret
+                  - secretsmanager:PutSecretValue
+                  - secretsmanager:DeleteSecret
+                Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CredentialsSecret-${AWS::StackName}*'
+        - PolicyName: LambdaLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/Base64EncoderFunction-${AWS::StackName}:*'
+
+  # Lambda Function for Base64 Encoding
+  Base64EncoderFunction:
+    Type: AWS::Lambda::Function
+    DependsOn:
+      - LambdaExecutionRole
+    Properties:
+      FunctionName: !Sub 'Base64EncoderFunction-${AWS::StackName}'
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        ZipFile: |
+          import json
+          import base64
+          import boto3
+          import cfnresponse
+          import logging
+
+          logging.basicConfig(level=logging.INFO)
+          logger = logging.getLogger()
+
+          def handler(event, context):
+              try:
+                  request_type = event['RequestType']
+                  props = event['ResourceProperties']
+                  plain_json = props['PlainJson']
+                  secret_name = props['SecretName']
+
+                  # Validate JSON input
+                  try:
+                      json.loads(plain_json)
+                  except json.JSONDecodeError:
+                      logger.error('Invalid JSON input')
+                      cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': 'Invalid JSON input'})
+
+                  # Encode plain JSON to base64
+                  base64_credentials = base64.b64encode(plain_json.encode('utf-8')).decode('utf-8')
+
+                  # Initialize Secrets Manager client with retries
+                  secrets_client = boto3.client('secretsmanager', config=boto3.session.Config(retries={'max_attempts': 3}))
+
+                  # Extract region and account ID
+                  region = context.invoked_function_arn.split(':')[3]
+                  account_id = context.invoked_function_arn.split(':')[4]
+                  secret_arn = f'arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}'
+
+                  logger.info(f'Processing {request_type} for secret: {secret_name}')
+                  if request_type == 'Create':
+                      secrets_client.create_secret(Name=secret_name, SecretString=base64_credentials)
+                      logger.info(f'Created secret: {secret_arn}')
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SecretArn': secret_arn})
+                  elif request_type == 'Update':
+                      secrets_client.put_secret_value(SecretId=secret_name, SecretString=base64_credentials)
+                      logger.info(f'Updated secret: {secret_arn}')
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SecretArn': secret_arn})
+                  elif request_type == 'Delete':
+                      try:
+                          secrets_client.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
+                          logger.info(f'Deleted secret: {secret_name}')
+                      except secrets_client.exceptions.ResourceNotFoundException:
+                          logger.info(f'Secret not found: {secret_name}, skipping deletion')
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                  else:
+                      logger.error(f'Invalid request type: {request_type}')
+                      cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': f'Invalid request type: {request_type}'})
+              except Exception as e:
+                  logger.error(f'Error: {str(e)}')
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)})
+      Runtime: python3.12
+      Timeout: 15
+      MemorySize: 128
+
+  # Custom Resource to Create Base64 Secret
+  Base64CredentialsSecret:
+    Type: Custom::Base64Secret
+    DependsOn:
+      - Base64EncoderFunction
+    Properties:
+      ServiceToken: !GetAtt Base64EncoderFunction.Arn
+      PlainJson: !Ref CredentialsJson
+      SecretName: !Sub 'CredentialsSecret-${AWS::StackName}'
+
+  # VPC Configuration
+  VPC:
+    Condition: CreateVPC
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VPCCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+
+  PublicSubnetOne:
+    Condition: CreateVPC
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ''
+      VpcId: !Ref VPC
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicOne', 'CIDR']
+      MapPublicIpOnLaunch: true
+
+  PublicSubnetTwo:
+    Condition: CreateVPC
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ''
+      VpcId: !Ref VPC
+      CidrBlock: !FindInMap ['SubnetConfig', 'PublicTwo', 'CIDR']
+      MapPublicIpOnLaunch: true
+
+  InternetGateway:
+    Condition: CreateVPC
+    Type: AWS::EC2::InternetGateway
+
+  GatewayAttachment:
+    Condition: CreateVPC
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Condition: CreateVPC
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  PublicRoute:
+    Condition: CreateVPC
+    Type: AWS::EC2::Route
+    DependsOn: GatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetOneRouteTableAssociation:
+    Condition: CreateVPC
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetOne
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetTwoRouteTableAssociation:
+    Condition: CreateVPC
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetTwo
+      RouteTableId: !Ref PublicRouteTable
+
+  # ECS Cluster
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      CapacityProviders:
+        - FARGATE
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: FARGATE
+          Weight: 1
+
+  # Security Groups
+  FargateContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the Fargate containers
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+
+  ApiGatewaySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: API Gateway traffic for 1Password Connect
+      VpcId: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+
+  # Security Group Rules
+  ApiGatewayEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref ApiGatewaySecurityGroup
+      IpProtocol: tcp
+      FromPort: 8080
+      ToPort: 8080
+      DestinationSecurityGroupId: !Ref FargateContainerSecurityGroup
+
+  ConnectIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref FargateContainerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 8080
+      ToPort: 8080
+      SourceSecurityGroupId: !Ref ApiGatewaySecurityGroup
+
+  ConnectSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from other containers in the same security group
+      GroupId: !Ref FargateContainerSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref FargateContainerSecurityGroup
+
+  ConnectPublicEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref FargateContainerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: 0.0.0.0/0
+      Description: HTTPS to external services (e.g., Docker Hub)
+
+  # IAM Roles
+  ECSTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AmazonECSTaskExecutionRolePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+        - PolicyName: SecretAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:CredentialsSecret-${AWS::StackName}*'
+
+  ECSRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ECSPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:AttachNetworkInterface
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:DetachNetworkInterface
+                Resource: '*'
+
+  # CloudWatch Logs
+  CloudWatchLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: onepassword-connect
+      RetentionInDays: 30
+
+  # Service Discovery
+  ServiceDiscoveryNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+      Description: Private DNS namespace for 1Password Connect
+      Vpc: !If [CreateVPC, !Ref VPC, !Ref VPCID]
+      Name: onepassword
+
+  ConnectServiceDiscovery:
+    Type: AWS::ServiceDiscovery::Service
+    DependsOn:
+      - ServiceDiscoveryNamespace
+    Properties:
+      DnsConfig:
+        DnsRecords:
+          - TTL: 60
+            Type: SRV
+      Name: connect
+      NamespaceId: !Ref ServiceDiscoveryNamespace
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+
+  # Task Definition
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - ECSTaskExecutionRole
+      - Base64CredentialsSecret
+      - CloudWatchLogsGroup
+    Properties:
+      Cpu: 256
+      Memory: 512
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !Ref ECSTaskExecutionRole
+      TaskRoleArn: !Ref ECSRole
+      Volumes:
+        - Name: data
+      ContainerDefinitions:
+        - Name: connect-api
+          Image: 1password/connect-api:latest
+          PortMappings:
+            - ContainerPort: 8080
+              Protocol: tcp
+          MountPoints:
+            - ContainerPath: /home/opuser/.op/data
+              SourceVolume: data
+          Secrets:
+            - Name: OP_SESSION
+              ValueFrom: !GetAtt Base64CredentialsSecret.SecretArn
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudWatchLogsGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: connect-api
+        - name: connect-sync
+          Image: 1password/connect-sync:latest
+          MountPoints:
+            - ContainerPath: /home/opuser/.op/data
+              SourceVolume: data
+          Environment:
+            - Name: OP_HTTP_PORT
+              Value: '8081'
+          Secrets:
+            - Name: OP_SESSION
+              ValueFrom: !GetAtt Base64CredentialsSecret.SecretArn
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudWatchLogsGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: connect-sync
+
+  # ECS Service
+  ConnectService:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - TaskDefinition
+      - Base64CredentialsSecret
+      - ApiGatewayStage
+      - ConnectServiceDiscovery
+    Properties:
+      ServiceName: connect
+      Cluster: !Ref ECSCluster
+      LaunchType: FARGATE
+      DesiredCount: 1
+      TaskDefinition: !Ref TaskDefinition
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref FargateContainerSecurityGroup
+          Subnets: !If
+            - CreateVPC
+            - [!Ref PublicSubnetOne, !Ref PublicSubnetTwo]
+            - !Ref PublicSubnets
+      ServiceRegistries:
+        - ContainerName: connect-api
+          ContainerPort: 8080
+          RegistryArn: !GetAtt ConnectServiceDiscovery.Arn
+
+  # API Gateway
+  VpcLink:
+    Type: AWS::ApiGatewayV2::VpcLink
+    Properties:
+      Name: connect-vpc-link
+      SecurityGroupIds:
+        - !Ref ApiGatewaySecurityGroup
+      SubnetIds: !If
+        - CreateVPC
+        - [!Ref PublicSubnetOne, !Ref PublicSubnetTwo]
+        - !Ref PublicSubnets
+
+  ApiGateway:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: onepassword-connect
+      ProtocolType: HTTP
+      Description: API Gateway for 1Password Connect
+
+  ApiGatewayIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    DependsOn:
+      - ApiGateway
+      - VpcLink
+    Properties:
+      ApiId: !Ref ApiGateway
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: ANY
+      ConnectionType: VPC_LINK
+      ConnectionId: !Ref VpcLink
+      IntegrationUri: !GetAtt ConnectServiceDiscovery.Arn
+      PayloadFormatVersion: 1.0
+
+  ApiGatewayRoute:
+    Type: AWS::ApiGatewayV2::Route
+    DependsOn:
+      - ApiGateway
+      - ApiGatewayIntegration
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: $default
+      AuthorizationType: NONE
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ApiGatewayIntegration
+
+  ApiGatewayStage:
+    Type: AWS::ApiGatewayV2::Stage
+    DependsOn:
+      - ApiGateway
+      - ApiGatewayRoute
+    Properties:
+      StageName: $default
+      ApiId: !Ref ApiGateway
+      AutoDeploy: true
+
+Outputs:
+  ExternalUrl:
+    Description: The URL of the API Gateway for 1Password Connect
+    Value: !GetAtt ApiGateway.ApiEndpoint
+    Export:
+      Name: !Join [ ':', [ !Ref AWS::StackName, 'ExternalUrl' ] ]


### PR DESCRIPTION
## Pull Request Description

This PR updates the 1Password Connect CloudFormation template for API Gateway to improve flexibility, security, and usability, aligning it with modern deployment practices. Key changes include:

- **Added VPC and Subnet Flexibility**: Introduced parameters (`VPCID`, `PublicSubnets`) to deploy into an existing VPC and subnets, with fallback to create a new VPC if not provided.
- **Simplified Credential Handling**: Replaced base64url-encoded input with plain JSON (`1Password-CredentialsJson`), using CloudFormation’s `!Base64` to encode credentials before storing them in Secrets Manager.
- **Improved Documentation**: Updated the README to reflect new features, and clarified parameter usage (e.g., `VPCCIDR` usage).

These changes make the template more adaptable to different network environments, enhance security by simplifying credential input, and improve the deployment experience with clearer guidance.