### PR TITLE
Add Terms of Service to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Check out our [developer documentation](https://developer.1password.com/docs/con
 - Join the [Developer Slack workspace](https://developer.1password.com/joinslack)
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)
 
+*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 ---
 
 With 1Password Connect, you can securely access your 1Password items and vaults in your company's apps and cloud infrastructure using a private REST API or the 1Password CLI.
+
+*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+
 ## ✨ Get started
 Check out our [developer documentation](https://developer.1password.com/docs/connect/get-started) to get started. Or see our deployment examples [here](https://github.com/1Password/connect/tree/main/examples).
 ## 💙 Community & Support
@@ -19,5 +22,3 @@ Check out our [developer documentation](https://developer.1password.com/docs/con
 - File an [issue](https://github.com/1Password/connect/issues) for bugs and feature requests.
 - Join the [Developer Slack workspace](https://developer.1password.com/joinslack)
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)
-
-*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 With 1Password Connect, you can securely access your 1Password items and vaults in your company's apps and cloud infrastructure using a private REST API or the 1Password CLI.
 
-*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+*Use of the 1Password APIs and services accessed through this project is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
 
 ## ✨ Get started
 Check out our [developer documentation](https://developer.1password.com/docs/connect/get-started) to get started. Or see our deployment examples [here](https://github.com/1Password/connect/tree/main/examples).

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Check out our [developer documentation](https://developer.1password.com/docs/con
 - File an [issue](https://github.com/1Password/connect/issues) for bugs and feature requests.
 - Join the [Developer Slack workspace](https://developer.1password.com/joinslack)
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)
+


### PR DESCRIPTION
This PR adds our new terms of service to the README, as requested by the legal team.

This update needs to merge on June 5th.

Relates to: https://1password.atlassian.net/browse/TW-1153